### PR TITLE
Pan Zoom

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "chartjs-plugin-trace",
-  "version": "1.0.6",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "chartjs-plugin-crosshair",
   "homepage": "https://chartjs-plugin-crosshair.netlify.com",
   "description": "Chart.js plugin to draw and sync vertical crosshair lines",
-  "version": "1.0.9",
+  "version": "1.1.0",
   "license": "MIT",
   "main": "dist/chartjs-plugin-crosshair.js",
   "repository": {

--- a/samples/index.html
+++ b/samples/index.html
@@ -1,174 +1,227 @@
 <!DOCTYPE html>
 <html lang="en-US">
-<head>
-	<meta charset="utf-8">
-	<meta http-equiv="X-UA-Compatible" content="IE=Edge">
-	<meta name="viewport" content="width=device-width, initial-scale=1">
-	<title>chartjs-plugin-trace / sample</title>
-	<link rel="stylesheet" type="text/css" href="index.css">
-	<link rel="icon" type="image/ico" href="favicon.ico">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>chartjs-plugin-trace / sample</title>
+    <link rel="stylesheet" type="text/css" href="index.css" />
+    <link rel="icon" type="image/ico" href="favicon.ico" />
 
-  <script src="https://cdn.jsdelivr.net/npm/chart.js@2.7.1/dist/Chart.min.js"></script>
-  <script src="../dist/chartjs-plugin-crosshair.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.7.1/dist/Chart.min.js"></script>
+    <script src="../dist/chartjs-plugin-crosshair.js"></script>
+  </head>
+  <body>
+    <div id="header">
+      <div class="title">
+        <span class="main">chartjs-plugin-crosshair</span>
+        <span class="name">Sample</span>
+      </div>
+      <div class="caption">
+        <a href="http://www.chartjs.org">Chart.js</a>
+        plugin to draw crosshair lines, interpolate values and zoom
+      </div>
+      <div class="links">
+        <a
+          class="btn btn-docs"
+          href="https://chartjs-plugin-crosshair.netlify.com"
+        >
+          Documentation
+        </a>
+        <a
+          class="btn btn-gh"
+          href="https://github.com/abelheinsbroek/chartjs-plugin-crosshair"
+        >
+          GitHub
+        </a>
+      </div>
+    </div>
+    <h3>Basic Example</h3>
+    <p>Try dragging to zoom in!</p>
+    <div class="chart"><canvas id="chart1"></canvas></div>
+    <h3>Linked Charts</h3>
+    <div class="split"><canvas id="chart2"></canvas></div>
+    <div class="split"><canvas id="chart3"></canvas></div>
+    <div class="chart"><canvas id="chart4"></canvas></div>
+    <h3>Panning Zoom</h3>
+    <p>Use left and right arrows to pan!</p>
+    <div class="chart"><canvas id="chart5"></canvas></div>
+  </body>
 
-</head>
-<body>
-	<div id="header">
-		<div class="title">
-			<span class="main">chartjs-plugin-crosshair</span>
-			<span class="name">Sample</span>
-		</div>
-		<div class="caption"><a href="http://www.chartjs.org">Chart.js</a> plugin to draw crosshair lines, interpolate values and zoom</div>
-		<div class="links">
-			<a class="btn btn-docs" href="https://chartjs-plugin-crosshair.netlify.com">Documentation</a>
-			<a class="btn btn-gh" href="https://github.com/abelheinsbroek/chartjs-plugin-crosshair">GitHub</a>
-		</div>
-	</div>
-	<h3>Basic Example</h3>
-	<p>Try dragging to zoom in!</p>
-	<div class='chart'>
-		<canvas id='chart1'></canvas>
-	</div>
-	<h3>Linked Charts</h3>
-	<div class='split'>
-		<canvas id='chart2'></canvas>
-	</div>
-	<div class='split'>
-		<canvas id='chart3'></canvas>
-	</div>
-	<div class='chart'>
-		<canvas id='chart4'></canvas>
-	</div>
-
-</body>
-
-<script>
-
-  function generateDataset(shift, label, color) {
-    var data = []
-    var x = 0
-    while (x < 30) {
-      data.push({'x':x,'y':Math.sin(shift+x/3)})
-      x+= Math.random()
+  <script>
+    function generateDataset(shift, label, color) {
+      var data = [];
+      var x = 0;
+      while (x < 30) {
+        data.push({ x: x, y: Math.sin(shift + x / 3) });
+        x += Math.random();
+      }
+      var dataset = {
+        backgroundColor: color,
+        borderColor: color,
+        showLine: true,
+        fill: false,
+        pointRadius: 2,
+        label: label,
+        data: data,
+        lineTension: 0,
+        interpolate: true
+      };
+      return dataset;
     }
-    var dataset = {
-      backgroundColor: color,
-      borderColor: color,
-      showLine: true,
-      fill: false,
-			pointRadius: 2,
-      label: label,
-      data: data,
-      lineTension: 0,
-			interpolate: true
-    }
-    return dataset
-  }
 
-  var chart1 = new Chart(document.getElementById("chart1").getContext('2d'), {
-    type: 'scatter',
-    options: {
-			plugins: {
-				crosshair: {
-					sync: {
-						enabled: false
-					}
-				}
-			},
+    var chart1 = new Chart(document.getElementById("chart1").getContext("2d"), {
+      type: "scatter",
+      options: {
+        plugins: {
+          crosshair: {
+            sync: {
+              enabled: false
+            }
+          }
+        },
 
-      tooltips: {
-        mode: 'interpolate',
-        intersect: false,
-        callbacks: {
-          title: function(a,d) {
-            return a[0].xLabel.toFixed(2)
-          }, 
-          label: function(i,d) {
-            return d.datasets[i.datasetIndex].label + ": " + i.yLabel.toFixed(2)
+        tooltips: {
+          mode: "interpolate",
+          intersect: false,
+          callbacks: {
+            title: function(a, d) {
+              return a[0].xLabel.toFixed(2);
+            },
+            label: function(i, d) {
+              return (
+                d.datasets[i.datasetIndex].label + ": " + i.yLabel.toFixed(2)
+              );
+            }
           }
         }
-      }
-    },
-    data: {
-
-      datasets: [
-        generateDataset(0, 'A', 'red'), 
-        generateDataset(1, 'B', 'green'),
-        generateDataset(2, 'C', 'blue'),
+      },
+      data: {
+        datasets: [
+          generateDataset(0, "A", "red"),
+          generateDataset(1, "B", "green"),
+          generateDataset(2, "C", "blue")
         ]
-    }
-  })
+      }
+    });
 
-  var chart2 = new Chart(document.getElementById("chart2").getContext('2d'), {
-    type: 'scatter',
-    options: {
-      tooltips: {
-        mode: 'interpolate',
-        intersect: false,
-        callbacks: {
-          title: function(a,d) {
-            return a[0].xLabel.toFixed(2)
-          }, 
-          label: function(i,d) {
-            return d.datasets[i.datasetIndex].label + ": " + i.yLabel.toFixed(2)
+    var chart2 = new Chart(document.getElementById("chart2").getContext("2d"), {
+      type: "scatter",
+      options: {
+        tooltips: {
+          mode: "interpolate",
+          intersect: false,
+          callbacks: {
+            title: function(a, d) {
+              return a[0].xLabel.toFixed(2);
+            },
+            label: function(i, d) {
+              return (
+                d.datasets[i.datasetIndex].label + ": " + i.yLabel.toFixed(2)
+              );
+            }
           }
         }
+      },
+      data: {
+        datasets: [generateDataset(0, "A", "red")]
       }
-    },
-    data: {
-      datasets: [
-        generateDataset(0, 'A', 'red'), 
-        ]
-    }
-  })
-  var chart3 = new Chart(document.getElementById("chart3").getContext('2d'), {
-    type: 'scatter',
-    options: {
-      tooltips: {
-        mode: 'interpolate',
-        intersect: false,
-        callbacks: {
-          title: function(a,d) {
-            return a[0].xLabel.toFixed(2)
-          }, 
-          label: function(i,d) {
-            return d.datasets[i.datasetIndex].label + ": " + i.yLabel.toFixed(2)
+    });
+    var chart3 = new Chart(document.getElementById("chart3").getContext("2d"), {
+      type: "scatter",
+      options: {
+        tooltips: {
+          mode: "interpolate",
+          intersect: false,
+          callbacks: {
+            title: function(a, d) {
+              return a[0].xLabel.toFixed(2);
+            },
+            label: function(i, d) {
+              return (
+                d.datasets[i.datasetIndex].label + ": " + i.yLabel.toFixed(2)
+              );
+            }
           }
         }
+      },
+      data: {
+        datasets: [generateDataset(1, "B", "green")]
       }
-    },
-    data: {
-      datasets: [
-        generateDataset(1, 'B', 'green'), 
-        ]
-    }
-  })
-  var chart4 = new Chart(document.getElementById("chart4").getContext('2d'), {
-    type: 'scatter',
-    options: {
-      tooltips: {
-        mode: 'interpolate',
-        intersect: false,
-        callbacks: {
-          title: function(a,d) {
-            return a[0].xLabel.toFixed(2)
-          }, 
-          label: function(i,d) {
-            return d.datasets[i.datasetIndex].label + ": " + i.yLabel.toFixed(2)
+    });
+    var chart4 = new Chart(document.getElementById("chart4").getContext("2d"), {
+      type: "scatter",
+      options: {
+        tooltips: {
+          mode: "interpolate",
+          intersect: false,
+          callbacks: {
+            title: function(a, d) {
+              return a[0].xLabel.toFixed(2);
+            },
+            label: function(i, d) {
+              return (
+                d.datasets[i.datasetIndex].label + ": " + i.yLabel.toFixed(2)
+              );
+            }
           }
         }
+      },
+      data: {
+        datasets: [generateDataset(1, "C", "blue")]
       }
-    },
-    data: {
-      datasets: [
-        generateDataset(1, 'C', 'blue'), 
+    });
+
+    var chart5 = new Chart(document.getElementById("chart5").getContext("2d"), {
+      type: "scatter",
+      options: {
+        plugins: {
+          crosshair: {
+            sync: {
+              enabled: false
+            },
+            pan: {
+              incrementer: 3 // Defaults to 5 if not included.
+            }
+          }
+        },
+        tooltips: {
+          mode: "interpolate",
+          intersect: false,
+          callbacks: {
+            title: function(a, d) {
+              return a[0].xLabel.toFixed(2);
+            },
+            label: function(i, d) {
+              return (
+                d.datasets[i.datasetIndex].label + ": " + i.yLabel.toFixed(2)
+              );
+            }
+          }
+        },
+        animation: {
+          duration: 0
+        },
+
+        responsiveAnimationDuration: 0
+      },
+      data: {
+        datasets: [
+          generateDataset(0, "A", "red"),
+          generateDataset(1, "B", "green"),
+          generateDataset(2, "C", "blue")
         ]
-    }
-  })
+      }
+    });
 
+    var panZoom = function(e) {
+      if (e.keyCode === 37) {
+        chart5.panZoomLeft();
+      } else if (e.keyCode === 39) {
+        chart5.panZoomRight();
+      }
+    };
 
-
-
-</script>
-
+    window.addEventListener("keydown", panZoom);
+  </script>
 </html>

--- a/samples/index.html
+++ b/samples/index.html
@@ -216,9 +216,9 @@
 
     var panZoom = function(e) {
       if (e.keyCode === 37) {
-        chart5.panZoomLeft();
+        chart5.panZoom(-5);
       } else if (e.keyCode === 39) {
-        chart5.panZoomRight();
+        chart5.panZoom(5);
       }
     };
 

--- a/src/trace.js
+++ b/src/trace.js
@@ -89,9 +89,6 @@ export default function(Chart) {
 			if (chart.crosshair.originalData.length === 0) {
 				return;
 			}
-			if (typeof increment !== 'number') {
-				throw new Error('chartjs-plugin-crosshair does not support non-number increments');
-			}
 			var diff = chart.crosshair.end - chart.crosshair.start;
 			var min = chart.crosshair.min;
 			var max = chart.crosshair.max;


### PR DESCRIPTION
Found your plugin super useful! I needed the ability to pan a zoomed portion of the branch, so I essentially reused your `doZoom` method and exposed the `panZoom` functionality on the chart instance. There should be no change to the existing `doZoom` method other than adding those properties to the `crosshair` object.

I bumped the minor version manually--I don't know your deployment scheme, so I can take this commit out if needed.

(Side note: sorry for the whitespace changes in `/samples/index.html`, my linter had its way with that file. Figured I'd leave it given it was taking queues from your eslintrc). 