### PR TITLE
Add `dashPattern` option for dashed crosshair line

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -27,8 +27,9 @@ new Chart(ctx, {
     plugins: {
       crosshair: {
         line: {
-          color: '#F66',  // crosshair line color
-          width: 1        // crosshair line width
+          color: '#F66',        // crosshair line color
+          width: 1,             // crosshair line width
+          dashPattern: [5, 5]   // crosshair line dash pattern
         },
         sync: {
           enabled: true,            // enable trace line syncing with other charts

--- a/docs/options.md
+++ b/docs/options.md
@@ -31,12 +31,15 @@ options: {
 | ---- | ---- | ----
 | [`color`](#color) | `String` | `#F66`
 | [`width`](#width) | `Number` | `1`
+| [`dashPattern`](#dash) | `Number[]` | `[]`
 
 
 #### `color`
 The color of the crosshair line, defaults to red (#F666)
 #### `width`
 The width of the crosshair line in pixels
+#### `dashPattern`
+Dash pattern of the crosshair line, specified as an array of values indicating alternating lengths of lines and gaps ([More info](https://developer.mozilla.org/en-US/docs/Web/API/CanvasRenderingContext2D/setLineDash))
 
 ### Chart interaction syncing
 The plugin allows for syncing crosshairs over multiple charts

--- a/src/trace.js
+++ b/src/trace.js
@@ -4,7 +4,8 @@ export default function(Chart) {
 	var defaultOptions = {
 		line: {
 			color: '#F66',
-			width: 1
+			width: 1,
+			dashPattern: []
 		},
 		sync: {
 			enabled: true,
@@ -462,13 +463,16 @@ export default function(Chart) {
 
 			var lineWidth = this.getOption(chart, 'line', 'width');
 			var color = this.getOption(chart, 'line', 'color');
+			var dashPattern = this.getOption(chart, 'line', 'dashPattern');
 
 			chart.ctx.beginPath();
+			chart.ctx.setLineDash(dashPattern);
 			chart.ctx.moveTo(chart.crosshair.x, yScale.getPixelForValue(yScale.max));
 			chart.ctx.lineWidth = lineWidth;
 			chart.ctx.strokeStyle = color;
 			chart.ctx.lineTo(chart.crosshair.x, yScale.getPixelForValue(yScale.min));
 			chart.ctx.stroke();
+			chart.ctx.setLineDash([]);
 
 		},
 


### PR DESCRIPTION
Add new option: `dashPattern` to enable rendering a dashed crosshair line.

Addresses #22 