### PR TITLE
Add new `snap` option to enable the crosshair to snap to datapoints

### DIFF
--- a/docs/options.md
+++ b/docs/options.md
@@ -85,6 +85,17 @@ Text of the button to reset the chart to original axis ranges.
 #### `zoomButtonClass`
 Class of the button to reset the chart to original axis ranges.
 
+### Snapping
+The plugin allows snapping to datapoints when used with `line` charts
+> This option requires the `hover.intersect` configuration option of your chart to be set to `false`.
+
+| Name | Type | Default
+| ---- | ---- | ----
+| [`enabled`](#enabled) | `Boolean` | `false`
+
+#### `enabled`
+Enable or disable snapping to point for `line` charts
+
 ### Callbacks
 
 The plugin exposes to callbacks to handle zooming

--- a/samples/snap.html
+++ b/samples/snap.html
@@ -1,0 +1,95 @@
+<!DOCTYPE html>
+<html lang="en-US">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="X-UA-Compatible" content="IE=Edge" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>chartjs-plugin-trace / sample</title>
+    <link rel="stylesheet" type="text/css" href="index.css" />
+    <link rel="icon" type="image/ico" href="favicon.ico" />
+
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@2.8.0/dist/Chart.min.js"></script>
+    <script src="../dist/chartjs-plugin-crosshair.js"></script>
+  </head>
+  <body>
+    <div id="header">
+      <div class="title">
+        <span class="main">chartjs-plugin-crosshair</span>
+        <span class="name">Sample</span>
+      </div>
+      <div class="caption">
+        <a href="http://www.chartjs.org">Chart.js</a>
+        plugin to draw crosshair lines, interpolate values and zoom
+      </div>
+      <div class="links">
+        <a
+          class="btn btn-docs"
+          href="https://chartjs-plugin-crosshair.netlify.com"
+        >
+          Documentation
+        </a>
+        <a
+          class="btn btn-gh"
+          href="https://github.com/abelheinsbroek/chartjs-plugin-crosshair"
+        >
+          GitHub
+        </a>
+      </div>
+    </div>
+    <h3>Snap Example</h3>
+    <div class="chart"><canvas id="chart1"></canvas></div>
+  </body>
+
+  <script>
+    function generateDataset(label, color) {
+      const data = Array.from({length: 12}, () => Math.floor(Math.random() * 12));
+      
+      return {
+        backgroundColor: color,
+        borderColor: color,
+        showLine: true,
+        fill: false,
+        pointRadius: 2,
+        label,
+        data,
+      };
+    }
+
+    var chart1 = new Chart(document.getElementById("chart1").getContext("2d"), {
+      type: "line",
+      options: {
+        plugins: {
+          crosshair: {
+            sync: {
+              enabled: false
+            },
+            zoom: {
+              enabled: false
+            },
+            snap: {
+              enabled: true
+            }
+          }
+        },
+
+        hover: {
+          intersect: false
+        },
+
+        tooltips: {
+          mode: "index",
+          intersect: false,
+        },
+
+      },
+      data: {
+        labels: ['Jan', 'Feb', 'Mar', 'Apr', 'May', 'Jun', 'Jul', 'Aug', 'Sep', 'Oct', 'Nov', 'Dec'],
+        datasets: [
+          generateDataset("A", "red"),
+          generateDataset("B", "green"),
+          generateDataset("C", "blue")
+        ]
+      }
+    });
+  </script>
+</html>

--- a/src/trace.js
+++ b/src/trace.js
@@ -19,6 +19,9 @@ export default function(Chart) {
 			zoomButtonText: 'Reset Zoom',
 			zoomButtonClass: 'reset-zoom',
 		},
+		snap: {
+			enabled: false,
+		},
 		callbacks: {
 			beforeZoom: function(start, end) {
 				return true;
@@ -41,7 +44,7 @@ export default function(Chart) {
 
 			var xScaleType = chart.config.options.scales.xAxes[0].type
 
-			if (xScaleType !== 'linear' && xScaleType !== 'time') {
+			if (xScaleType !== 'linear' && xScaleType !== 'time' && xScaleType !== 'category') {
 				return;
 			}
 
@@ -170,7 +173,7 @@ export default function(Chart) {
 
 			var xScaleType = chart.config.options.scales.xAxes[0].type
 
-			if (xScaleType !== 'linear' && xScaleType !== 'time') {
+			if (xScaleType !== 'linear' && xScaleType !== 'time' && xScaleType !== 'category') {
 				return;
 			}
 
@@ -464,13 +467,21 @@ export default function(Chart) {
 			var lineWidth = this.getOption(chart, 'line', 'width');
 			var color = this.getOption(chart, 'line', 'color');
 			var dashPattern = this.getOption(chart, 'line', 'dashPattern');
+			var snapEnabled = this.getOption(chart, 'snap', 'enabled');
+
+			var lineX = chart.crosshair.x;
+			var isHoverIntersectOff = chart.config.options.hover.intersect === false;
+
+			if (snapEnabled && isHoverIntersectOff && chart.active.length) {
+				lineX = chart.active[0]._view.x;
+			}
 
 			chart.ctx.beginPath();
 			chart.ctx.setLineDash(dashPattern);
-			chart.ctx.moveTo(chart.crosshair.x, yScale.getPixelForValue(yScale.max));
+			chart.ctx.moveTo(lineX, yScale.getPixelForValue(yScale.max));
 			chart.ctx.lineWidth = lineWidth;
 			chart.ctx.strokeStyle = color;
-			chart.ctx.lineTo(chart.crosshair.x, yScale.getPixelForValue(yScale.min));
+			chart.ctx.lineTo(lineX, yScale.getPixelForValue(yScale.min));
 			chart.ctx.stroke();
 			chart.ctx.setLineDash([]);
 


### PR DESCRIPTION
This new option works for `line` charts and snaps the crosshair to the active datapoint.

Addresses #24 