### PR TITLE
Fix: typo in variable 'xScaleType'.

### DIFF
--- a/src/trace.js
+++ b/src/trace.js
@@ -44,7 +44,7 @@ export default function(Chart) {
 
 			var xScaleType = chart.config.options.scales.xAxes[0].type
 
-			if (xScaleType !== 'linear' && xScaleType !== 'time' && xScaleType !== 'category' && xscaleType !== 'logarithmic') {
+			if (xScaleType !== 'linear' && xScaleType !== 'time' && xScaleType !== 'category' && xScaleType !== 'logarithmic') {
 				return;
 			}
 


### PR DESCRIPTION
There was a typo in the variable 'xScaleType' causing an error when initializing the plugin in a 'logarithmic' scale type, or an non-supported scale type.
Please accept the pull request and release the fix. 👍 