### PR TITLE
Add checks to prevent plugin activation

### DIFF
--- a/src/trace.js
+++ b/src/trace.js
@@ -248,6 +248,9 @@ export default function(Chart) {
 
 		afterDraw: function(chart) {
 
+			if (chart.config.options.scales.xAxes.length == 0) {
+				return;
+			}
 			if (!chart.crosshair.enabled) {
 				return;
 			}
@@ -264,6 +267,9 @@ export default function(Chart) {
 		},
 
 		beforeTooltipDraw: function(chart) {
+			if (chart.config.options.scales.xAxes.length == 0) {
+				return;
+			}
 			// suppress tooltips on dragging
 			return !chart.crosshair.dragStarted && !chart.crosshair.suppressTooltips;
 		},

--- a/src/trace.js
+++ b/src/trace.js
@@ -30,6 +30,11 @@ export default function(Chart) {
 			}
 		}
 	};
+	
+	function isShouldIgnorePlugin(chart) {
+		return !chart || !chart.config || !chart.config.options || !chart.config.options.scales ||
+		  !chart.config.options.scales.xAxes || !chart.config.options.scales.xAxes.length;
+	}
 
 	var crosshairPlugin = {
 
@@ -37,7 +42,7 @@ export default function(Chart) {
 
 		afterInit: function(chart) {
 
-			if (chart.config.options.scales.xAxes.length == 0) {
+			if (isShouldIgnorePlugin(chart)) {
 				return
 			}
 
@@ -89,6 +94,9 @@ export default function(Chart) {
 		},
 
 		destroy: function(chart) {
+			if (isShouldIgnorePlugin(chart)) {
+				return;
+			}
 			var syncEnabled = this.getOption(chart, 'sync', 'enabled');
 			if (syncEnabled) {
 				window.removeEventListener('sync-event', chart.crosshair.syncEventHandler);
@@ -127,6 +135,9 @@ export default function(Chart) {
 
 		handleSyncEvent: function(chart, e) {
 
+			if (isShouldIgnorePlugin(chart)) {
+				return;
+			}
 			var syncGroup = this.getOption(chart, 'sync', 'group');
 
 			// stop if the sync event was fired from this chart
@@ -166,7 +177,7 @@ export default function(Chart) {
 
 		afterEvent: function(chart, e) {
 
-			if (chart.config.options.scales.xAxes.length == 0) {
+			if (isShouldIgnorePlugin(chart)) {
 				return
 			}
 
@@ -248,7 +259,7 @@ export default function(Chart) {
 
 		afterDraw: function(chart) {
 
-			if (chart.config.options.scales.xAxes.length == 0) {
+			if (isShouldIgnorePlugin(chart)) {
 				return;
 			}
 			if (!chart.crosshair.enabled) {
@@ -267,7 +278,7 @@ export default function(Chart) {
 		},
 
 		beforeTooltipDraw: function(chart) {
-			if (chart.config.options.scales.xAxes.length == 0) {
+			if (isShouldIgnorePlugin(chart)) {
 				return;
 			}
 			// suppress tooltips on dragging


### PR DESCRIPTION
Well, at my bad I have many charts at my page and I headed up with this issue: `Line` chart doesn't work with `Pie` chart if this plugin is registered. That's happened because `Pie` chart trying to access some options which are undefined.

This PR adds some additional checks to prevent access undefined options and make this plugin works with any chart with defines not empty property `chart.config.options.scales.xAxes`. Otherwise any event's will be ignored.