### PR TITLE
fix typo in afterEvent

### DIFF
--- a/src/trace.js
+++ b/src/trace.js
@@ -175,7 +175,7 @@ export default {
 
     var xScaleType = chart.config.options.scales.x.type
 
-    if (xScaleType !== 'linear' && xScaleType !== 'time' && xScaleType !== 'category' && xscaleType !== 'logarithmic') {
+    if (xScaleType !== 'linear' && xScaleType !== 'time' && xScaleType !== 'category' && xScaleType !== 'logarithmic') {
       return;
     }
 


### PR DESCRIPTION
Fixes typo in `afterEvent` so `xscaleType` -> `xScaleType`