### PR TITLE
chore: update chart.js version in peer dependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -45,6 +45,6 @@
     "yargs": "^16.2.0"
   },
   "peerDependencies": {
-    "chart.js": "^3.4.0"
+    "chart.js": "^4.0.1"
   }
 }


### PR DESCRIPTION
The plugin seems to work correctly with `Chart.js` 4.x so the PR updates `peerDependencies` to reflect that.