### PR TITLE
Fix chart event sync

### DIFF
--- a/src/trace.js
+++ b/src/trace.js
@@ -152,12 +152,19 @@ export default {
     }
 
 
+    // do not transmit click events to prevent unwanted changing of synced
+    // charts. We do need to transmit an event to stop zooming on synced
+    // charts however.
+    var eventType = e.original.type == "click" ? "mousemove" : e.original.type;
+
     var newEvent = {
-      type: e.original.type == "click" ? "mousemove" : e.original.type,  // do not transmit click events to prevent unwanted changing of synced charts. We do need to transmit a event to stop zooming on synced charts however.
+      type: eventType,
       chart: chart,
       x: xScale.getPixelForValue(e.xValue),
       y: e.original.y,
       native: {
+        // ChartJS filters events to plugins by the event's native type
+        type: eventType,
         buttons: buttons
       },
       stop: true


### PR DESCRIPTION
Fixes Issue: https://github.com/AbelHeinsbroek/chartjs-plugin-crosshair/issues/95

## Context

This issue was caused by a change in [github.com/chartjs/Chart.js/pull/9613](https://github.com/chartjs/Chart.js/pull/9613/files#diff-37e14a9c8aebcc4556ce11fc01eaca256a3dfed7bcd87edf520838cc6119723bR1070) where the chart event controller started filtering the events to plugins by the event's native type:

Previously
```
const eventFilter = (plugin) => (plugin.options.events || this.options.events).includes(e.type);
```

Now
```
const eventFilter = (plugin) => (plugin.options.events || this.options.events).includes(e.native.type);
```

The plugin `chartjs-plugin-crosshair` syncs events by passing them through the chart's `_eventHandler` again, yet failed to specify the event's `native.type`

## Fix

The fix was to implement a form of @bolau's suggestion (https://github.com/AbelHeinsbroek/chartjs-plugin-crosshair/issues/95#issuecomment-1661903271) where we preserve the `event.type` and add the `event.native.type`

> It seems that the fix by @geriatricdan is already contained in the repository code, but at the wrong place:
>
> ```
> var newEvent = {
>   type: e.original.type == "click" ? "mousemove" : e.original.type,  // do not transmit click events to prevent unwanted changing of synced charts. We do need to transmit a event to stop zooming on synced charts however.
>   chart: chart,
>   x: xScale.getPixelForValue(e.xValue),
>   y: e.original.y,
>   native: {
>     // INSERTED HERE
>     type: e.original.type == "click" ? "mousemove" : e.original.type,  // do not transmit click events to prevent unwanted changing of synced charts. We do need to transmit a event to stop zooming on synced charts however.
>     buttons: buttons
>   },
>   stop: true
> };
> ```

## Testing

I've confirmed that this fix works on Chrome (Version 115.0.5790.170 (Official Build) (x86_64)) with:

```
"chart.js": "4.3.3",
"chartjs-plugin-crosshair": "2.0.0",
"react-chartjs-2": "5.2.0",
```

### Example

| Before | After |
| ----- | ----- |
| <img width="1146" alt="broken-sync" src="https://github.com/AbelHeinsbroek/chartjs-plugin-crosshair/assets/137209244/4a44f18e-3e69-4348-967b-50b3e86fb691"> | <img width="1152" alt="fixed-sync" src="https://github.com/AbelHeinsbroek/chartjs-plugin-crosshair/assets/137209244/ac824c99-9021-4c6a-90b3-a691ef171816"> |
| Event does not sync | Event does sync |

